### PR TITLE
EMMA-37:ServiceImpl.getDAO should not be public

### DIFF
--- a/2.x/src/main/resources/archetype-resources/api/src/main/java/api/impl/__D-moduleClassPrefix__ServiceImpl.java
+++ b/2.x/src/main/resources/archetype-resources/api/src/main/java/api/impl/__D-moduleClassPrefix__ServiceImpl.java
@@ -33,8 +33,9 @@ public class ${D-moduleClassPrefix}ServiceImpl extends BaseOpenmrsService implem
     
     /**
      * @return the dao
+     * dao
      */
-    public ${D-moduleClassPrefix}DAO getDao() {
+    private ${D-moduleClassPrefix}DAO getDao;{
 	    return dao;
     }
 }


### PR DESCRIPTION
Description of what i did;
I changed the "public XyzDAO getDao()" method in the ServiceImpl method into private XyzDAO getDao().

Ticket worked on:
https://issues.openmrs.org/browse/EMMA-37